### PR TITLE
docs: Vale lint fixes for reference architecture section

### DIFF
--- a/docs/sources/tempo/reference-tempo-architecture/_index.md
+++ b/docs/sources/tempo/reference-tempo-architecture/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Tempo architecture reference
 menuTitle: Architecture reference
-description: Detailed reference for Tempo's architecture, components, and design decisions.
+description: Detailed reference for the Tempo architecture, components, and design decisions.
 weight: 600
 topicType: introduction
 versionDate: 2026-03-20
@@ -9,7 +9,7 @@ versionDate: 2026-03-20
 
 # Tempo architecture reference
 
-This section provides a detailed technical reference for Grafana Tempo's architecture.
+This section provides a detailed technical reference for the Grafana Tempo architecture.
 For a high-level overview, refer to the [Tempo architecture](https://grafana.com/docs/tempo/<TEMPO_VERSION>/introduction/architecture/) page.
 
 {{< section menuTitle="true" >}}

--- a/docs/sources/tempo/reference-tempo-architecture/about-tempo-architecture/_index.md
+++ b/docs/sources/tempo/reference-tempo-architecture/about-tempo-architecture/_index.md
@@ -1,5 +1,5 @@
 ---
-title: About Tempo's architecture
+title: About the Tempo architecture
 menuTitle: About the architecture
 description: Understand the design philosophy and data flow in Tempo.
 weight: 100
@@ -7,14 +7,14 @@ topicType: concept
 versionDate: 2026-03-20
 ---
 
-# About Tempo's architecture
+# About the Tempo architecture
 
 Grafana Tempo is a distributed tracing backend designed for high-volume trace ingestion and querying at scale.
 Tempo 3.0 introduces a new architecture that decouples the write and read paths using a Kafka-compatible message queue as a durable intermediary.
 
 ## Design philosophy
 
-Tempo's architecture is built around several key principles.
+The Tempo architecture is built around several key principles.
 
 Separate components handle writing trace data to storage and serving queries.
 You can scale writes and reads independently, and a failure in one path doesn't affect the other.

--- a/docs/sources/tempo/reference-tempo-architecture/components/block-builder.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/block-builder.md
@@ -46,7 +46,7 @@ it produces the same block IDs on retry, safely overwriting any partial data fro
 
 ## Flush and recovery
 
-The flush process is designed to be safely replayable at every stage.
+The flush process supports safe replay at every stage.
 
 ### Flush order
 
@@ -58,7 +58,7 @@ The block-builder flushes blocks to object storage in a specific order:
 1. `meta.json` (the block becomes "live" at this point)
 
 A block isn't visible to the read path until its `meta.json` is written.
-Before that point, any crash is fully recoverable — the block-builder rewinds and overwrites.
+Before that point, any crash is fully recoverable—the block-builder rewinds and overwrites.
 
 ### Recovering from partial flushes
 
@@ -87,7 +87,7 @@ This prevents a race condition where a backend worker might try to compact a blo
 Each block-builder instance consumes from one or more Kafka partitions.
 The maximum number of block-builder instances equals the number of Kafka partitions.
 
-Block-builders use static partition assignment. There's no Kafka consumer group rebalancing.
+Block-builders use static partition assignment. Kafka does not move partitions between consumers in the consumer group for this component.
 There are two ways to assign partitions:
 
 - `partitions_per_instance`: Each instance computes which partitions it owns based on its ordinal ID.

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -16,7 +16,7 @@ Together, they handle compaction, retention, and blocklist maintenance for data 
 
 The backend scheduler creates jobs and assigns them to workers.
 Workers connect to the scheduler via gRPC, request jobs, execute them, and report results back.
-This split makes compaction horizontally scalable — you can add workers to increase throughput without changing the scheduler.
+This split makes compaction horizontally scalable—you can add workers to increase throughput without changing the scheduler.
 
 ### Job types
 
@@ -62,7 +62,7 @@ This distributes the load of scanning object storage across all workers.
 
 Workers use a ring for tenant sharding.
 The ring determines which worker is responsible for polling each tenant's blocklist.
-By default the ring is disabled (unsharded), meaning each worker polls all tenants.
+By default the ring is disabled, meaning each worker polls all tenants without sharding.
 
 ```yaml
 backend_worker:

--- a/docs/sources/tempo/reference-tempo-architecture/components/distributor.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/distributor.md
@@ -70,7 +70,7 @@ This has two benefits:
 - Block-builders can build blocks where all spans for a trace are co-located (within a single consumption cycle).
 - Live-stores can serve complete traces from a single partition without cross-partition coordination.
 
-The distributor uses the partition ring (not Kafka's native partitioner) to determine target partitions.
+The distributor uses the partition ring (not Kafka's partition routing) to determine target partitions.
 This allows Tempo to control the partition lifecycle independently of Kafka.
 
 ## Key metrics

--- a/docs/sources/tempo/reference-tempo-architecture/components/kafka.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/kafka.md
@@ -16,7 +16,7 @@ Any Kafka-compatible system works.
 
 Kafka serves as a durable write-ahead log (WAL) between distributors and downstream consumers (block-builders, live-stores, and metrics-generators).
 
-With Kafka, durability is centralized. Once Kafka acknowledges a write, the data is safe regardless of what happens to any Tempo component. Consumers are stateless — block-builders and live-stores can crash and restart, replaying from their last committed Kafka offset to rebuild state without data loss. Because Kafka provides durability, Tempo doesn't need to replicate data across multiple instances on the write path, enabling a replication factor of 1 that significantly reduces storage costs.
+With Kafka, durability is centralized. Once Kafka acknowledges a write, the data is safe regardless of what happens to any Tempo component. Consumers are stateless—block-builders and live-stores can crash and restart, replaying from their last committed Kafka offset to rebuild state without data loss. Because Kafka provides durability, Tempo doesn't need to replicate data across multiple instances on the write path, enabling a replication factor of 1 that significantly reduces storage costs.
 
 ## Partitioning
 

--- a/docs/sources/tempo/reference-tempo-architecture/components/live-store.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/live-store.md
@@ -27,7 +27,7 @@ and periodically flushing traces to a local WAL in Parquet format for TraceQL se
 When the live-store receives spans from Kafka, it assembles them into traces in memory.
 Each trace goes through three stages.
 
-First, the trace is active — it's receiving spans, remains in memory, and is queryable.
+First, the trace is active—it's receiving spans, remains in memory, and is queryable.
 Then, when no new spans have arrived within the configured `max_trace_idle`
 the trace becomes idle and is flushed to the local WAL.
 Once flushed, the trace data is written in Parquet format and becomes available for TraceQL search.
@@ -90,9 +90,9 @@ Refer to the [zone-aware live-stores](https://grafana.com/docs/tempo/<TEMPO_VERS
 
 When traces are flushed from memory, they're written to a local WAL in Parquet format. This serves two purposes.
 
-First, it provides search availability — once in the WAL,
+First, it provides search availability—after data is in the WAL,
 trace data is available for TraceQL search queries, not just trace ID lookups.
-Second, it aids recovery on restart — if the live-store restarts,
+Second, it aids recovery on restart—if the live-store restarts,
 it can replay from Kafka, and the WAL provides a way to serve queries during replay.
 
 The WAL is eventually cut into complete blocks that are also stored locally.

--- a/docs/sources/tempo/reference-tempo-architecture/components/metrics-generator.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/metrics-generator.md
@@ -16,7 +16,7 @@ which are then remote-written to a metrics backend, for example, Prometheus or G
 
 Traces contain rich information about service interactions, latencies, and error rates.
 The metrics-generator extracts this information and produces time-series metrics,
-enabling alerting and dashboarding without requiring separate instrumentation.
+enabling alerting and Grafana dashboards without requiring separate instrumentation.
 
 It supports two types of metric generation.
 Span metrics produce request rate, error rate, and duration (RED) metrics from individual spans.

--- a/docs/sources/tempo/reference-tempo-architecture/components/querier.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/querier.md
@@ -35,7 +35,7 @@ If a live-store is unavailable, the querier falls back to the live-store in the 
 
 ## Backend queries
 
-For historical data, the querier consults the blocklist (maintained by backend workers) to find blocks in the relevant time range. It uses bloom filters to quickly eliminate blocks that don't contain the target trace ID, fetches matching block data from object storage (using caching where configured), and deserializes the Parquet data and applies any TraceQL filters.
+For historical data, the querier consults the blocklist (maintained by backend workers) to find blocks in the relevant time range. It uses bloom filters to quickly eliminate blocks that don't contain the target trace ID, fetches matching block data from object storage (using caching where configured), reads the Parquet data, and applies any TraceQL filters.
 
 ### Caching
 
@@ -49,7 +49,7 @@ Lower-level caches (bloom, Parquet page) have higher hit rates and should be siz
 
 The number of jobs a querier processes concurrently is controlled by `max_concurrent_queries` (the maximum number of jobs processed at once) or `frontend_worker.parallelism` (the number of connections to each query frontend, which determines concurrent batch processing).
 
-Increasing concurrency makes queriers process more jobs in parallel but increases memory usage. If queriers are OOMing, reduce concurrency and scale horizontally instead.
+Increasing concurrency makes queriers process more jobs in parallel but increases memory usage. If queriers run out of memory, reduce concurrency and scale horizontally instead.
 
 ### Memory sizing
 

--- a/docs/sources/tempo/reference-tempo-architecture/deployment-modes.md
+++ b/docs/sources/tempo/reference-tempo-architecture/deployment-modes.md
@@ -39,17 +39,17 @@ Monolithic mode is suitable for getting started, development environments, and l
 
 ### Limitations
 
-All components share the same resource pool. A spike in query load can affect write throughput and vice versa. There's no independent scaling — you can run multiple monolithic instances, but each runs every component. At higher volumes, memory pressure from collocated components (particularly live-store and querier) can cause OOM issues.
+All components share the same resource pool. A spike in query load can affect write throughput and vice versa. There's no independent scaling—you can run multiple monolithic instances, but each runs every component. At higher volumes, memory pressure from collocated components (particularly live-store and querier) can cause out-of-memory (OOM) issues.
 
 ### Resource considerations
 
-Monolithic instances need enough memory to handle the live-store's in-memory trace buffer, the querier's concurrent job execution, the block-builder's scratch space, and the backend worker's memory for block merging. As volume increases, the instance becomes bottlenecked by whichever component is most resource-hungry.
+Monolithic instances need enough memory to handle the live-store's in-memory trace buffer, the querier's concurrent job execution, the block-builder's scratch space, and the backend worker's memory for block merging. As volume increases, the instance is limited by whichever component is most resource-hungry.
 
 ### Example
 
-Find docker-compose deployment examples in the Tempo repository: [https://github.com/grafana/tempo/tree/main/example/docker-compose](https://github.com/grafana/tempo/tree/main/example/docker-compose/)
+Refer to [Docker Compose examples in the Tempo repository](https://github.com/grafana/tempo/tree/main/example/docker-compose/) for sample deployments.
 
-To see an annotated example configuration for Tempo, the [Introduction To MLTP](https://github.com/grafana/intro-to-mltp) example repository contains a [configuration](https://github.com/grafana/intro-to-mltp/blob/main/tempo/tempo.yaml) for a monolithic instance.
+For an annotated example configuration for Tempo, refer to the [Introduction to MLTP](https://github.com/grafana/intro-to-mltp) repository, which includes a [sample `tempo.yaml`](https://github.com/grafana/intro-to-mltp/blob/main/tempo/tempo.yaml) for a monolithic instance.
 
 ## Microservices mode
 
@@ -63,7 +63,7 @@ Use microservices mode for production deployments, high trace volumes requiring 
 
 ### Advantages
 
-Microservices mode provides independent scaling — you can scale block-builders for write throughput, queriers for query performance, and live-stores for recent data capacity, all independently. Failure domains are isolated: a querier OOM doesn't affect data ingestion, and a block-builder restart doesn't affect query availability. Live-stores can be deployed across availability zones for high availability. Each component gets exactly the resources it needs, avoiding the over-provisioning required in monolithic mode.
+Microservices mode provides independent scaling—you can scale block-builders for write throughput, queriers for query performance, and live-stores for recent data capacity, all independently. Failure domains are isolated: a querier OOM doesn't affect data ingestion, and a block-builder restart doesn't affect query availability. Live-stores can be deployed across availability zones for high availability. Each component gets exactly the resources it needs, avoiding the over-provisioning required in monolithic mode.
 
 ### Component scaling guidelines
 
@@ -85,7 +85,7 @@ Adding or removing instances of any component doesn't require reconfiguring othe
 
 ### Example
 
-Find a docker-compose deployment example at [https://github.com/grafana/tempo/tree/main/example/docker-compose/distributed](https://github.com/grafana/tempo/tree/main/example/docker-compose/distributed).
+Refer to the [distributed Docker Compose example](https://github.com/grafana/tempo/tree/main/example/docker-compose/distributed) in the Tempo repository.
 
 ## Migrating between modes
 

--- a/docs/sources/tempo/reference-tempo-architecture/object-storage.md
+++ b/docs/sources/tempo/reference-tempo-architecture/object-storage.md
@@ -53,7 +53,7 @@ Tenants are fully isolated at the storage level. Each tenant's blocks are in a s
 
 With Tempo 3.0's Kafka-based architecture, durability works in layers.
 
-Kafka provides immediate durability. Once data is acknowledged by Kafka, it's safe even if all Tempo components crash. Object storage provides long-term durability. Once the block-builder flushes a block, the data is durably stored and independent of Kafka. Kafka retention bridges the gap — Kafka retains data long enough for block-builders to consume and flush it. If a block-builder is slow or restarting, Kafka holds the data until it's processed.
+Kafka provides immediate durability. Once data is acknowledged by Kafka, it's safe even if all Tempo components crash. Object storage provides long-term durability. Once the block-builder flushes a block, the data is durably stored and independent of Kafka. Kafka retention bridges the gap—Kafka retains data long enough for block-builders to consume and flush it. If a block-builder is slow or restarting, Kafka holds the data until it's processed.
 
 There's no single point of failure for data durability. Kafka and object storage together provide end-to-end safety.
 

--- a/docs/sources/tempo/reference-tempo-architecture/partition-ring.md
+++ b/docs/sources/tempo/reference-tempo-architecture/partition-ring.md
@@ -9,7 +9,7 @@ versionDate: 2026-03-20
 
 # Partition ring
 
-The partition ring is Tempo's mechanism for tracking which partitions exist, their current state, and which components own them.
+The partition ring is the mechanism Tempo uses to track which partitions exist, their current state, and which components own them.
 By default, the partition ring propagates across the cluster via memberlist gossip and is central to how distributors, live-stores, and block-builders coordinate.
 
 ## Tempo partitions vs Kafka partitions
@@ -54,7 +54,7 @@ After this grace period, you can safely remove the partition and its owning live
 ### Live-stores
 
 Each Tempo partition is owned by one live-store per availability zone.
-In a zone-aware deployment with two zones, each partition has two owners — one per zone.
+In a zone-aware deployment with two zones, each partition has two owners—one per zone.
 Both consume the same Kafka partition independently.
 
 When a live-store starts, it checks the ring for its assigned partition.
@@ -80,7 +80,7 @@ The live-store creates a new partition in the ring (pending state).
 After enough owners register and the waiting period elapses, the partition transitions to active,
 and distributors begin writing to the new partition.
 
-A corresponding Kafka partition must exist — add Kafka partitions first if needed.
+A corresponding Kafka partition must exist—add Kafka partitions first if needed.
 
 ### Scaling down
 
@@ -98,7 +98,7 @@ Changes to the ring (new partitions, state transitions) propagate across the clu
 
 During network partitions or high cluster churn, propagation may be delayed.
 This can cause brief inconsistencies where different components have different views of the ring.
-Tempo handles this gracefully — distributors writing to a partition that a live-store hasn't yet seen results in data that's picked up once the live-store catches up,
+Tempo handles this gracefully—distributors writing to a partition that a live-store hasn't yet seen results in data that's picked up after the live-store catches up,
 and queriers contacting a live-store for a partition it doesn't own yet get an empty response,
 with the data eventually available from another live-store or from object storage.
 


### PR DESCRIPTION
## Summary

Addresses Grafana Vale **errors** in `docs/sources/tempo/reference-tempo-architecture/` (em-dash spacing, spelling/dictionary wording, product possessives, deployment example link text).

Intended to merge into the open architecture PR on `3.0-reference-arch`.

## Verification

- `vale docs/sources/tempo/reference-tempo-architecture/` → 0 errors

Made with [Cursor](https://cursor.com)