### PR TITLE
Sonic 32bit arch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Add span profiling support via otelpyroscope. Enable with `span_profiling: true` (or `-span-profiling` CLI flag) to attach pprof labels to OTel spans. [#7063](https://github.com/grafana/tempo/pull/7063) (@simonswine)
 * [BUGFIX] Fix tempo-vulture ignoring `-tempo-push-tls` flag in normal operating mode. [#6974](https://github.com/grafana/tempo/pull/6974) (@xaque208)
+* [BUGFIX] Fix release build failure on 32-bit architectures (e.g. linux/arm) caused by sonic JSON library. Fall back to encoding/json on archs sonic does not support. (@mapno)
 * [CHANGE] **BREAKING CHANGE** Remove duplicate "compaction" prefix from CompactorConfig CLI flags. Affected flags: `compaction.block-retention`, `compaction.max-objects-per-block`, `compaction.max-block-bytes`, `compaction.compaction-window`. [#6909](https://github.com/grafana/tempo/pull/6909) (@electron0zero)
 * [CHANGE] **BREAKING CHANGE** Enable RetryInfo by default. `distributor.retry_after_on_resource_exhausted` now defaults to `5s` (was `0`) so OTLP clients receive a retry hint on `ResourceExhausted` errors. [#7088](https://github.com/grafana/tempo/pull/7088) (@electron0zero)
   Set to `0` to disable cluster-wide, or set the per-tenant override `ingestion.retry_info_enabled: false` to disable for a single tenant.

--- a/pkg/util/jsonx/json_sonic.go
+++ b/pkg/util/jsonx/json_sonic.go
@@ -1,0 +1,36 @@
+//go:build (amd64 && go1.17 && !go1.27) || (arm64 && go1.20 && !go1.27)
+
+// Package jsonx wraps the JSON encoder used across Tempo. On amd64/arm64 with
+// supported Go versions it delegates to github.com/bytedance/sonic for the
+// fast path; on every other arch (notably 32-bit linux/arm in our release
+// matrix) it falls back to encoding/json.
+//
+// Why this package exists:
+//
+// sonic ships a compat fallback that *should* let it compile everywhere,
+// but vendor/github.com/bytedance/sonic/internal/utils/skip.go contains a
+// deliberate compile-time tripwire on 32-bit archs:
+//
+//	const _Sonic_Not_Support_32Bit_Arch__Checking_32Bit_Arch_Here = ...
+//
+// Because that file is transitively imported by sonic/ast (which is always
+// built), any direct `import "github.com/bytedance/sonic"` breaks the
+// linux/arm release build. This package isolates sonic behind build tags so
+// callers can stay arch-agnostic.
+//
+// Do not import github.com/bytedance/sonic directly from anywhere else in
+// the tree — a depguard lint rule rejects it.
+//
+// Build tags above mirror those in github.com/bytedance/sonic/sonic.go so
+// that this file is only compiled on archs+versions where sonic itself
+// compiles its native path.
+package jsonx
+
+//nolint:depguard // jsonx is the one place sonic is allowed; see package doc above
+import "github.com/bytedance/sonic"
+
+// Marshal returns the JSON encoding of v.
+func Marshal(v any) ([]byte, error) { return sonic.Marshal(v) }
+
+// Unmarshal parses the JSON-encoded data and stores the result in v.
+func Unmarshal(data []byte, v any) error { return sonic.Unmarshal(data, v) }

--- a/pkg/util/jsonx/json_std.go
+++ b/pkg/util/jsonx/json_std.go
@@ -1,0 +1,17 @@
+//go:build !((amd64 && go1.17 && !go1.27) || (arm64 && go1.20 && !go1.27))
+
+package jsonx
+
+// See json_sonic.go for the rationale behind this build-tag split. On archs
+// where sonic cannot be imported (e.g. 32-bit linux/arm in release builds, or
+// any non-amd64/non-arm64 arch), fall back to encoding/json. Output bytes are
+// equivalent for the types this package is used with in Tempo (no maps with
+// non-deterministic ordering, no custom Marshalers relying on sonic specifics).
+
+import "encoding/json"
+
+// Marshal returns the JSON encoding of v.
+func Marshal(v any) ([]byte, error) { return json.Marshal(v) }
+
+// Unmarshal parses the JSON-encoded data and stores the result in v.
+func Unmarshal(data []byte, v any) error { return json.Unmarshal(data, v) }

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -6,11 +6,11 @@ import (
 	"slices"
 	"time"
 
-	"github.com/bytedance/sonic"
 	"github.com/cespare/xxhash/v2"
 	"github.com/google/uuid"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/pkg/util/jsonx"
 )
 
 // DedicatedColumnType is the type of the values in the dedicated attribute column. Only 'string' is supported.
@@ -195,13 +195,13 @@ func (dc *DedicatedColumn) MarshalJSON() ([]byte, error) {
 	if cpy.Type == DefaultDedicatedColumnType {
 		cpy.Type = ""
 	}
-	return sonic.Marshal(&cpy)
+	return jsonx.Marshal(&cpy)
 }
 
 func (dc *DedicatedColumn) UnmarshalJSON(b []byte) error {
 	type dcAlias DedicatedColumn // alias required to avoid recursive calls of UnmarshalJSON
 
-	err := sonic.Unmarshal(b, (*dcAlias)(dc))
+	err := jsonx.Unmarshal(b, (*dcAlias)(dc))
 	if err != nil {
 		return err
 	}
@@ -226,7 +226,7 @@ func (dcs *DedicatedColumns) UnmarshalJSON(b []byte) error {
 	}
 
 	type dcsAlias DedicatedColumns // alias required to avoid recursive calls of UnmarshalJSON
-	err := sonic.Unmarshal(b, (*dcsAlias)(dcs))
+	err := jsonx.Unmarshal(b, (*dcsAlias)(dcs))
 	if err != nil {
 		return err
 	}
@@ -427,7 +427,7 @@ func (dcs DedicatedColumns) Marshal() ([]byte, error) {
 	}
 
 	// NOTE: The json bytes interned in a map to avoid re-unmarshalling the same byte slice.
-	return sonic.Marshal(dcs)
+	return jsonx.Marshal(dcs)
 }
 
 func (dcs DedicatedColumns) MarshalTo(data []byte) (n int, err error) {
@@ -446,7 +446,7 @@ func (dcs *DedicatedColumns) Unmarshal(data []byte) error {
 	}
 
 	// NOTE: The json bytes interned in a map to avoid re-unmarshalling the same byte slice.
-	return sonic.Unmarshal(data, &dcs)
+	return jsonx.Unmarshal(data, &dcs)
 }
 
 func (b *CompactedBlockMeta) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

The bytedance/sonic library introduced in #6262 contains a deliberate compile-time tripwire on 32-bit architectures
(internal/utils/skip.go: _Sonic_Not_Support_32Bit_Arch__Checking_32Bit_Arch_Here), which breaks the release build for linux/arm. Sonic ships a compat fallback to encoding/json, but that fallback path still transitively imports internal/utils via the always-built ast package, so simply importing sonic on 32-bit fails to compile.

Introduce pkg/util/jsonx that exposes Marshal/Unmarshal and selects the implementation via build tags mirroring sonic's own: sonic on amd64/ arm64, encoding/json everywhere else. Reroute the four call sites in tempodb/backend through it.

Add a depguard lint rule rejecting direct imports of bytedance/sonic anywhere outside the wrapper, with a //nolint:depguard escape hatch in the wrapper itself. This prevents the same release fire from being relit by future code that reaches for sonic without the build-tag gating.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`